### PR TITLE
Add non-blocking movement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ stepper.run_to_position_mm(1000)
 
 stepper.run_to_position_mm(400)
 
+``run_to_position_steps`` blocks until the movement is finished.  Pass
+``blocking=False`` to start the movement in a background thread and return
+immediately. Call :py:meth:`stop` from another thread to abort the movement or
+use ``wait_for_movement_finished_threaded()`` to wait for it to finish.
+
 
 #-----------------------------------------------------------------------
 # move the motor 1 revolution

--- a/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
+++ b/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
@@ -198,11 +198,12 @@ class CL57TStepperDriver:
                 self.run_to_position_steps(
                     999999999,
                     movement_abs_rel=MovementAbsRel.RELATIVE,
-                    stop_condition=lambda : homing_sensor_value() is False
+                    stop_condition=lambda : homing_sensor_value() is False,
+                    blocking=True,
                 )
 
                 self.cl57t_logger.log("moving back a bit more", Loglevel.INFO)
-                self.run_to_position_steps(50, movement_abs_rel=MovementAbsRel.RELATIVE)
+                self.run_to_position_steps(50, movement_abs_rel=MovementAbsRel.RELATIVE, blocking=True)
 
         do_not_touch_homing_sensor()
 
@@ -210,7 +211,8 @@ class CL57TStepperDriver:
         self.run_to_position_steps(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True
+            stop_condition=lambda : homing_sensor_value() is True,
+            blocking=True,
         )
         self.cl57t_logger.log("first homing reached", Loglevel.INFO)
 
@@ -222,7 +224,8 @@ class CL57TStepperDriver:
         self.run_to_position_steps(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True
+            stop_condition=lambda : homing_sensor_value() is True,
+            blocking=True,
         )
 
         self.cl57t_logger.log("second homing reached", Loglevel.INFO)


### PR DESCRIPTION
## Summary
- make `run_to_position_steps` non-blocking and runnable in a thread
- preserve old behaviour through a `blocking=True` flag
- adjust higher level helpers to use `blocking=True`
- document new behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683add38ab44832d825f0df144717c6b